### PR TITLE
FIX: global declarations were error nodes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -126,7 +126,7 @@ module.exports = grammar({
 
     global_binding: $ => seq(
       optional($.declaration_attribute),
-      $.identifier, ':', $.type, optional(seq('=', $.expression)),
+      $.identifier, optional(seq(':', $.type)), optional(seq('=', $.expression)),
     ),
 
     declaration_attribute: $ => seq(


### PR DESCRIPTION
Small error in the grammar, the hare compiler allows implicit type in globals. Just changed the type param to be `optional(seq(":", $.type))`.

I also regenerated the bindings, not sure what the general convention for pr's is.